### PR TITLE
Split custom emoji mappings from auto-generated mappings.

### DIFF
--- a/custom_emoji_map.json
+++ b/custom_emoji_map.json
@@ -1,0 +1,12 @@
+{
+ "rc": [
+  "rc",
+  "recursecenter",
+  "hs",
+  "hackerschool"
+  ],
+ "pink_heart": [
+  "❤️",
+  "heart"
+ ]
+}

--- a/emoji_map.json
+++ b/emoji_map.json
@@ -1,14 +1,4 @@
 {
- "rc": [
-  "rc",
-  "recursecenter",
-  "hs",
-  "hackerschool"
-  ],
- "pink_heart": [
-  "❤️",
-  "heart"
- ],
  "u0023_20e3": [
   "#⃣",
   "u0023_20e3",

--- a/octopusholdings.py
+++ b/octopusholdings.py
@@ -4,12 +4,16 @@ from flask import Flask, render_template, send_from_directory
 
 app = Flask(__name__)
 
-with open('emoji_map.json', 'r') as f:
-    emoji_dict = json.load(f)
-    emoji_aliases = dict()
-    for emoji in emoji_dict.keys():
-        for alias in emoji_dict[emoji]:
-            emoji_aliases[alias] = emoji
+def load_emoji(filename, emoji_aliases):
+    with open(filename, 'r') as f:
+        emoji_dict = json.load(f)
+        for emoji in emoji_dict.keys():
+            for alias in emoji_dict[emoji]:
+                emoji_aliases[alias] = emoji
+
+emoji_aliases = dict()
+load_emoji('emoji_map.json', emoji_aliases)
+load_emoji('custom_emoji_map.json', emoji_aliases)
 
 
 @app.route('/')


### PR DESCRIPTION
This avoids accidentally overwriting custom mappings when emoji mappings are
regenerated.